### PR TITLE
option to hide express errors

### DIFF
--- a/src/handlers/express.ts
+++ b/src/handlers/express.ts
@@ -79,6 +79,8 @@ export function expressErrorHandler(options: { next: boolean } = { next: false }
       }
       AgentRegistrar.getCurrentAgent().captureError(error);
     }
-    options.next && next(error);
+    if (options.next) {
+      next(error);
+    }
   };
 }


### PR DESCRIPTION
The duplicate error in our RemoteJS logs were caused because the express error handler passes the error onto the `next` handler. Since we didn't have anything else, it falls onto the default Express handler, which logs it with stacktrace to `console.error`, where we catch it again.

I change the behavior to not pass the error through to next anymore, and added an option to allow the user to expose the error if they have their own additional handler.