### PR TITLE
send cors header to expose correlation header

### DIFF
--- a/src/handlers/express.ts
+++ b/src/handlers/express.ts
@@ -56,6 +56,7 @@ export function expressRequestHandler(
         // We push the current correlationId out as a header so that a TrackJS
         // agent on the client-side of the request can link up with us.
         res.setHeader("TrackJS-Correlation-Id", correlationId);
+        res.setHeader("Access-Control-Expose-Headers", "TrackJS-Correlation-Id");
       }
 
       next();

--- a/test/handlers/express.test.ts
+++ b/test/handlers/express.test.ts
@@ -40,6 +40,13 @@ describe("expressRequestHandler", () => {
       expect(fakeAgent.environment.url).toBe("https://example.com/");
     });
   });
+
+  it("sets correlation headers on response", () => {
+    expressRequestHandler({ correlationHeader: true })(fakeReq, fakeRes, () => {
+      expect(fakeRes.hasHeader("TrackJS-Correlation-Id")).toBe(true);
+      expect(fakeRes.getHeader("Access-Control-Expose-Headers")).toBe("TrackJS-Correlation-Id");
+    });
+  });
 });
 
 describe("expressErrorHandler", () => {


### PR DESCRIPTION
If the node process is cross-origin from the client, the browser agent will not be able to read the header without allowing it in CORS. This allows the client to see the header.