### PR TITLE
Update the Node Agent to use http.request as the core wrapping thing …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.0
+
+- Update NetworkWatcher to instrument the `request` method instead of the private `_http_agent` method, which breaks on some platforms.
+
 ## 1.0.2
 
 Update packages and verify new node version

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trackjs-node",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "TrackJS Error Tracking agent for NodeJS",
   "keywords": [
     "error-tracking",


### PR DESCRIPTION
…instead of the private _http_agent we used before that breaks in NextJS

This was preventing the server-side portion of NextJS 14+ from working.