### PR TITLE
Added a `TrackJS.console` object for parity with the browser agent.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trackjs-node",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "TrackJS Error Tracking agent for NodeJS",
   "keywords": [
     "error-tracking",
@@ -32,7 +32,7 @@
     "test:network": "node ./test/integration/network",
     "test:require": "node ./test/integration/require",
     "test:transmit": "node ./test/integration/transmit",
-    "test:jest": "jest",
+    "test:jest": "jest --forceExit",
     "test:watch": "jest --watch",
     "version": "node ./tools/version"
   },

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -131,6 +131,24 @@ export function addLogTelemetry(severity: string, ...messages: any): void {
 }
 
 /**
+ * For parity with the browser agent, add a set of helper functions that resembles the
+ * console object hanging off TrackJS.
+ */
+export const console = {
+  log: (...messages: any): void => addLogTelemetry("log", ...messages),
+  info: (...messages: any): void => addLogTelemetry("info", ...messages),
+  debug: (...messages: any): void => addLogTelemetry("debug", ...messages),
+  warn: (...messages: any): void => addLogTelemetry("warn", ...messages),
+  error: (...messages: any): void => {
+    if (!hasInstalled) {
+      throw new TrackJSError("not installed.");
+    }
+    let error = isError(messages) ? messages : new Error(serialize(messages));
+    AgentRegistrar.getCurrentAgent().captureError(error, TrackJSEntry.Console);
+  }
+};
+
+/**
  * Attach a event handler to Errors. Event handlers will be called in order
  * they were attached.
  *


### PR DESCRIPTION
A customer asked for this for easier switching between client- and server- contexts