### PR TITLE
Add `network` options for installation. Fix wrapping of `http.get`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.3.0
+
+- Added installation options for `network.enabled` and `network.error` to control whether network telemetry and errors are captured.
+- Fixed wrapping of `http.get` and `https.get` to add telemetry events.
+
 ## 1.2.0
 
 - Added `TrackJS.console` function for parity with the browser agent.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trackjs-node",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trackjs-node",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "devDependencies": {
         "@types/jest": "29.5.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trackjs-node",
-  "version": "1.0.2",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trackjs-node",
-      "version": "1.0.2",
+      "version": "1.2.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "devDependencies": {
         "@types/jest": "29.5.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trackjs-node",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "TrackJS Error Tracking agent for NodeJS",
   "keywords": [
     "error-tracking",

--- a/src/Agent.ts
+++ b/src/Agent.ts
@@ -9,6 +9,7 @@ import { deduplicate, truncate } from "./agentHelpers";
 import { uuid } from "./utils/uuid";
 import { RELEASE_VERSION } from "./version";
 import { TrackJSEntry } from "./types/TrackJSCapturePayload";
+import { nestedAssign } from "./utils/nestedAssign";
 
 export class Agent {
   static defaults: TrackJSOptions = {
@@ -18,6 +19,10 @@ export class Agent {
     dependencies: true,
     errorURL: "https://capture.trackjs.com/capture/node",
     faultURL: "https://usage.trackjs.com/fault.gif",
+    network: {
+      error: true,
+      enabled: true
+    },
     sessionId: "",
     usageURL: "https://usage.trackjs.com/usage.gif",
     userId: "",
@@ -32,16 +37,13 @@ export class Agent {
   private _onErrorFns = [];
 
   constructor(options: TrackJSInstallOptions) {
-    this.options = Object.assign({}, Agent.defaults, options);
-    this.options.correlationId = this.options.correlationId;
+    this.options = nestedAssign({}, Agent.defaults, options);
 
     if (isFunction(options.onError)) {
       this.onError(options.onError);
-      delete this.options.onError;
     }
 
     this.metadata = new Metadata(this.options.metadata);
-    delete this.options.metadata;
 
     if (this.options.defaultMetadata) {
       this.metadata.add("hostname", os.hostname());

--- a/src/Agent.ts
+++ b/src/Agent.ts
@@ -41,9 +41,11 @@ export class Agent {
 
     if (isFunction(options.onError)) {
       this.onError(options.onError);
+      delete this.options.onError;
     }
 
     this.metadata = new Metadata(this.options.metadata);
+    delete this.options.metadata;
 
     if (this.options.defaultMetadata) {
       this.metadata.add("hostname", os.hostname());

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -43,9 +43,12 @@ export function install(options: TrackJSInstallOptions): void {
   }
 
   try {
-    AgentRegistrar.init(new Agent(options));
-    watchers.forEach((w) => w.install());
-    AgentRegistrar.getCurrentAgent().captureUsage();
+    const agent = new Agent(options);
+    AgentRegistrar.init(agent);
+    for (const watcher of watchers) {
+      watcher.install(agent.options);
+    }
+    agent.captureUsage();
     hasInstalled = true;
   } catch (error) {
     captureFault(error);

--- a/src/types/TrackJSOptions.ts
+++ b/src/types/TrackJSOptions.ts
@@ -55,6 +55,21 @@ export interface TrackJSOptions {
   metadata?: { [key: string]: string };
 
   /**
+   * Network telemetry options
+   */
+  network?: {
+    /**
+     * Whether an error should be captured when a network request returns a 400 or greater status code
+     */
+    error?: boolean;
+
+    /**
+     * Whether network requests should automatically be recorded as Telemetry
+     */
+    enabled?: boolean;
+  };
+
+  /**
    * Custom callback handler for errors detected.
    */
   onError?: (payload: TrackJSCapturePayload) => boolean;

--- a/src/utils/nestedAssign.ts
+++ b/src/utils/nestedAssign.ts
@@ -1,0 +1,26 @@
+/**
+ * nestedAssign
+ * Assigns the properties from the source objects onto the target. Unlike
+ * object.assign, this follows nested objects and assigns the properties from each
+ * nested object as well.
+ *
+ * @param {target} object Target object
+ * @param {...sources} object[] Source objects
+ * @return {object}
+ */
+export function nestedAssign(target: object, ...sources: object[]): object {
+  for (const source of sources) {
+    for (const key of Object.keys(source)) {
+      if (typeof source[key] === "object") {
+        if (!target[key]) {
+          // create an empty target nested object so we don't manipulate the sources
+          Object.assign(target, { [key]: {} });
+        }
+        nestedAssign(target[key], source[key]);
+      } else {
+        Object.assign(target, { [key]: source[key] });
+      }
+    }
+  }
+  return target;
+}

--- a/src/watchers/ConsoleWatcher.ts
+++ b/src/watchers/ConsoleWatcher.ts
@@ -4,6 +4,7 @@ import { AgentRegistrar } from "../AgentRegistrar";
 import { Watcher } from "./Watcher";
 import { TrackJSEntry } from "../types/TrackJSCapturePayload";
 import { isError } from "../utils/isType";
+import { TrackJSOptions } from "../types";
 
 const CONSOLE_FN_NAMES = ["debug", "info", "warn", "error", "log"];
 
@@ -12,7 +13,7 @@ class _ConsoleWatcher implements Watcher {
    * @inheritdoc
    * @param _console {Object} override of the global console object.
    */
-  install(_console?: Object): void {
+  install(options: TrackJSOptions, _console?: Object): void {
     let consoleObj = _console || console;
     CONSOLE_FN_NAMES.forEach((name) => {
       patch(consoleObj, name, function(originalFn) {

--- a/src/watchers/ExceptionWatcher.ts
+++ b/src/watchers/ExceptionWatcher.ts
@@ -1,12 +1,13 @@
 import { AgentRegistrar } from "../AgentRegistrar";
 import { Watcher } from ".";
 import { TrackJSEntry } from "../types/TrackJSCapturePayload";
+import { TrackJSOptions } from "../types";
 
 class _ExceptionWatcher implements Watcher {
   /**
    * @inheritdoc
    */
-  install(): void {
+  install(options: TrackJSOptions): void {
     process.on("uncaughtException", this.handleException);
   }
 

--- a/src/watchers/NetworkWatcher.ts
+++ b/src/watchers/NetworkWatcher.ts
@@ -8,40 +8,50 @@ import { TrackJSEntry } from "../types/TrackJSCapturePayload";
 import { TrackJSOptions } from "../types";
 
 class _NetworkWatcher implements Watcher {
+
+  private options: TrackJSOptions;
+
   /**
    * @inheritdoc
    */
   install(options: TrackJSOptions): void {
-    if (!options.network.enabled) {
+    this.options = options;
+
+    if (!this.options.network.enabled) {
       return;
     }
 
-    [http, https].forEach((module) => {
-      patch(module, "request", (original) => {
-        return function request(outgoing) {
-          let req = original.apply(this, arguments);
+    const networkWatcher = this;
+    for(const module of [http, https]) {
+      for (const method of ["request", "get"]) {
+        patch(module, method, (original) => {
+          return function request(options) {
+            const req = original.apply(this, arguments);
 
-          if (!(outgoing || {})["__trackjs__"]) {
-            let networkTelemetry = _NetworkWatcher.createTelemetryFromRequest(req);
-            AgentRegistrar.getCurrentAgent(req["domain"]).telemetry.add("n", networkTelemetry);
+            if (!options?.__trackjs__)  {
+              const networkTelemetry = networkWatcher.createTelemetryFromRequest(req);
+              AgentRegistrar.getCurrentAgent(req.domain).telemetry.add("n", networkTelemetry);
+            }
+
+            return req;
           }
-
-          return req;
-        };
-      });
-    });
+        })
+      }
+    }
   }
 
   /**
    * @inheritdoc
    */
   uninstall(): void {
-    [http, https].forEach((module) => {
-      unpatch(module, "request");
-    });
+    for(const module of [http, https]) {
+      for (const method of ["request", "get"]) {
+        unpatch(module, method);
+      }
+    }
   }
 
-  static createTelemetryFromRequest(request: http.ClientRequest): NetworkTelemetry {
+  createTelemetryFromRequest(request: http.ClientRequest): NetworkTelemetry {
     let networkTelemetry = new NetworkTelemetry();
     networkTelemetry.type = "http";
     networkTelemetry.startedOn = new Date().toISOString();
@@ -57,7 +67,7 @@ class _NetworkWatcher implements Watcher {
       networkTelemetry.statusText = response.statusMessage;
       networkTelemetry.completedOn = new Date().toISOString();
 
-      if (networkTelemetry.statusCode >= 400) {
+      if (this.options.network.error && networkTelemetry.statusCode >= 400) {
         AgentRegistrar.getCurrentAgent(request["domain"]).captureError(
           new Error(
             `${networkTelemetry.statusCode} ${networkTelemetry.statusText}: ${networkTelemetry.method} ${networkTelemetry.url}`

--- a/src/watchers/NetworkWatcher.ts
+++ b/src/watchers/NetworkWatcher.ts
@@ -5,12 +5,17 @@ import { NetworkTelemetry } from "../telemetry";
 import { AgentRegistrar } from "../AgentRegistrar";
 import { Watcher } from "./Watcher";
 import { TrackJSEntry } from "../types/TrackJSCapturePayload";
+import { TrackJSOptions } from "../types";
 
 class _NetworkWatcher implements Watcher {
   /**
    * @inheritdoc
    */
-  install(): void {
+  install(options: TrackJSOptions): void {
+    if (!options.network.enabled) {
+      return;
+    }
+
     [http, https].forEach((module) => {
       patch(module, "request", (original) => {
         return function request(outgoing) {

--- a/src/watchers/RejectionWatcher.ts
+++ b/src/watchers/RejectionWatcher.ts
@@ -3,12 +3,13 @@ import { Watcher } from ".";
 import { isError } from "../utils/isType";
 import { serialize } from "../utils/serialize";
 import { TrackJSEntry } from "../types/TrackJSCapturePayload";
+import { TrackJSOptions } from "../types";
 
 class _RejectionWatcher implements Watcher {
   /**
    * @inheritdoc
    */
-  install(): void {
+  install(options: TrackJSOptions): void {
     process.on("unhandledRejection", this.rejectionHandler);
   }
 

--- a/src/watchers/Watcher.ts
+++ b/src/watchers/Watcher.ts
@@ -1,3 +1,5 @@
+import { TrackJSOptions } from "../types";
+
 /**
  * Watches for a particular situation in the environment and handles notifying
  * the running agent appropriately.
@@ -7,7 +9,7 @@ export interface Watcher {
    * Install the watcher into the environment.
    * @see uninstall
    */
-  install(): void;
+  install(options: TrackJSOptions): void;
 
   /**
    * Removes the watcher from the environment.

--- a/test/Agent.test.ts
+++ b/test/Agent.test.ts
@@ -17,6 +17,10 @@ describe("Agent", () => {
         dependencies: false,
         errorURL: "https://mycapture.com/",
         faultURL: "https://myfault.com/",
+        network: {
+          error: true,
+          enabled: false
+        },
         sessionId: "session",
         usageURL: "https://myusage.com/",
         userId: "user",
@@ -27,10 +31,10 @@ describe("Agent", () => {
     });
 
     it("initializes with default options", () => {
-      let options = {
+      const options = {
         token: "token"
       };
-      let agent = new Agent(options);
+      const agent = new Agent(options);
       expect(agent.options).toEqual({
         token: "token",
         application: "",
@@ -38,6 +42,10 @@ describe("Agent", () => {
         errorURL: "https://capture.trackjs.com/capture/node",
         defaultMetadata: true,
         dependencies: true,
+        network: {
+          error: true,
+          enabled: true
+        },
         sessionId: "",
         usageURL: "https://usage.trackjs.com/usage.gif",
         userId: "",
@@ -229,11 +237,6 @@ describe("Agent", () => {
         onError: handler
       };
       let agent = new Agent(options);
-      expect(agent.options).not.toEqual(
-        expect.objectContaining({
-          onError: handler
-        })
-      );
       agent.captureError(new Error("test message"), TrackJSEntry.Direct);
       expect(handler).toHaveBeenCalled();
     });

--- a/test/integration/network/index.js
+++ b/test/integration/network/index.js
@@ -9,7 +9,7 @@ const { TrackJS } = require('../../../dist');
 
 console.log('Starting Networking Test...');
 
-const TESTS_EXPECTED = 4;
+const TESTS_EXPECTED = 6;
 let testsComplete = 0;
 
 function testComplete() {
@@ -28,7 +28,7 @@ function assertStrictEqual(thing1, thing2) {
 
 TrackJS.install({
   token: '8de4c78a3ec64020ab2ad15dea1ae9ff',
-  onError: function(payload) {
+  onError: (payload) => {
     switch(payload.customer.userId) {
       case 'http':
         assertStrictEqual(payload.message, '503 Service Unavailable: GET http://httpstat.us/503');
@@ -37,6 +37,7 @@ TrackJS.install({
         assertStrictEqual(payload.network.length, 1);
         assertStrictEqual(payload.network[0].statusCode, 503);
         assertStrictEqual(payload.network[0].type, 'http');
+        console.log('http request PASSED');
         break;
       case 'https':
         assertStrictEqual(payload.message, '404 Not Found: GET https://httpstat.us/404');
@@ -45,6 +46,25 @@ TrackJS.install({
         assertStrictEqual(payload.network.length, 1);
         assertStrictEqual(payload.network[0].statusCode, 404);
         assertStrictEqual(payload.network[0].type, 'http');
+        console.log('https request PASSED');
+        break;
+      case 'http.get':
+        assertStrictEqual(payload.message, '502 Bad Gateway: GET http://httpstat.us/502');
+        assertStrictEqual(payload.entry, 'ajax');
+        assertStrictEqual(payload.console.length, 0);
+        assertStrictEqual(payload.network.length, 1);
+        assertStrictEqual(payload.network[0].statusCode, 502);
+        assertStrictEqual(payload.network[0].type, 'http');
+        console.log('http.get request PASSED');
+        break;
+      case 'https.get':
+        assertStrictEqual(payload.message, '403 Forbidden: GET https://httpstat.us/403');
+        assertStrictEqual(payload.entry, 'ajax');
+        assertStrictEqual(payload.console.length, 0);
+        assertStrictEqual(payload.network.length, 1);
+        assertStrictEqual(payload.network[0].statusCode, 403);
+        assertStrictEqual(payload.network[0].type, 'http');
+        console.log('https.get request PASSED');
         break;
       case 'request':
         assertStrictEqual(payload.message, '501 Not Implemented: GET https://httpstat.us/501');
@@ -53,6 +73,7 @@ TrackJS.install({
         assertStrictEqual(payload.network.length, 1);
         assertStrictEqual(payload.network[0].statusCode, 501);
         assertStrictEqual(payload.network[0].type, 'http');
+        console.log('request PASSED');
         break;
       case 'axios':
         assertStrictEqual(payload.message, '401 Unauthorized: GET https://httpstat.us/401');
@@ -61,6 +82,7 @@ TrackJS.install({
         assertStrictEqual(payload.network.length, 1);
         assertStrictEqual(payload.network[0].statusCode, 401);
         assertStrictEqual(payload.network[0].type, 'http');
+        console.log('Axoim request PASSED');
         break;
       default:
         console.log('unknown userId error', payload);
@@ -72,21 +94,33 @@ TrackJS.install({
   }
 });
 
-process.on('uncaughtException', function(error) {
+process.on('uncaughtException', (error) => {
   if (!error['__trackjs__']) {
     console.log('UNCAUGHT PROCESS ERROR', error);
     process.exit(1);
   }
 });
 
+domain.create('http.get').run(() => {
+  TrackJS.configure({ userId: 'http.get' });
+  http.get('http://httpstat.us/502');
+});
+
+domain.create('https.get').run(() => {
+  TrackJS.configure({ userId: 'https.get' });
+  https.get('https://httpstat.us/403');
+});
+
 domain.create('http').run(() => {
   TrackJS.configure({ userId: 'http' });
-  http.get('http://httpstat.us/503');
+  const req = http.request('http://httpstat.us/503', { method: "GET" });
+  req.end();
 });
 
 domain.create('https').run(() => {
   TrackJS.configure({ userId: 'https' });
-  https.get('https://httpstat.us/404');
+  const req = https.request('https://httpstat.us/404', { method: "GET" });
+  req.end();
 });
 
 domain.create('request').run(() => {

--- a/test/utils/nestedAssign.test.ts
+++ b/test/utils/nestedAssign.test.ts
@@ -1,0 +1,64 @@
+import { nestedAssign } from "../../src/utils/nestedAssign";
+
+describe("nestedAssign()", () => {
+  it("assigns properties from objects", () => {
+    const a = { foo: "foo" };
+    const b = { bar: "bar" };
+    const c = { foo: "baz" };
+    const result = nestedAssign({}, a, b, c);
+    expect(result).not.toBe(a);
+    expect(result).not.toBe(b);
+    expect(result).not.toBe(c);
+    expect(result).toEqual({
+      foo: "baz",
+      bar: "bar"
+    });
+  });
+
+  it("assigns nested properties from objects when always provided", () => {
+    const a = { foo: "foo", nested: { bar: "bar", baz: "baz" } };
+    const b = { foo: "zzz", nested: { bar: "xxx", baz: "yyy" } };
+    const result = nestedAssign({}, a, b);
+    expect(result).toEqual({
+      foo: "zzz",
+      nested: {
+        bar: "xxx",
+        baz: "yyy"
+      }
+    });
+  });
+
+  it("assigns nested properties from objects when not provided", () => {
+    const a = { foo: "foo", nested: { bar: "bar", baz: "baz" } };
+    const b = { foo: "zzz" };
+    const result = nestedAssign({}, a, b);
+    expect(result).toEqual({
+      foo: "zzz",
+      nested: {
+        bar: "bar",
+        baz: "baz"
+      }
+    });
+  });
+
+  it("assigns nested properties from objects when partial provided", () => {
+    const a = { foo: "foo", nested: { bar: "bar", baz: "baz" } };
+    const b = { foo: "zzz", nested: { baz: "xxx" } };
+    const result = nestedAssign({}, a, b);
+    expect(result).toEqual({
+      foo: "zzz",
+      nested: {
+        bar: "bar",
+        baz: "xxx"
+      }
+    });
+  });
+
+  it("doesn't manipulate the sources", () => {
+    const a = { foo: "foo", nested: { bar: "bar", baz: "baz" } };
+    const b = { foo: "zzz", nested: { baz: "xxx" } };
+    const result = nestedAssign({}, a, b);
+    expect(a).toEqual({ foo: "foo", nested: { bar: "bar", baz: "baz" } });
+    expect(b).toEqual({ foo: "zzz", nested: { baz: "xxx" } });
+  });
+});

--- a/test/watchers/ConsoleWatcher.test.ts
+++ b/test/watchers/ConsoleWatcher.test.ts
@@ -11,10 +11,12 @@ beforeAll(() => {
 
 describe("ConsoleWatcher", () => {
   describe("install()", () => {
+    let fakeOptions = null;
     let fakeConsole = null;
     let fakeAgent = null;
 
     beforeEach(() => {
+      fakeOptions = {};
       fakeConsole = jest.mock("console");
       fakeAgent = new Agent({ token: "test" });
       AgentRegistrar.init(fakeAgent);
@@ -26,21 +28,21 @@ describe("ConsoleWatcher", () => {
 
     it("console patches add telemetry", () => {
       fakeAgent.telemetry.add = jest.fn();
-      _ConsoleWatcher.install(fakeConsole);
+      _ConsoleWatcher.install(fakeOptions, fakeConsole);
       fakeConsole.log("a log message");
       expect(fakeAgent.telemetry.add).toHaveBeenCalledWith("c", expect.any(ConsoleTelemetry));
     });
 
     it("calls through to console", () => {
       let consoleLogSpy = jest.spyOn(fakeConsole, "log");
-      _ConsoleWatcher.install(fakeConsole);
+      _ConsoleWatcher.install(fakeOptions, fakeConsole);
       fakeConsole.log("a log message", 2, 3, 4);
       expect(consoleLogSpy).toHaveBeenCalledWith("a log message", 2, 3, 4);
     });
 
     it("captures on console error", () => {
       fakeAgent.captureError = jest.fn((error) => null);
-      _ConsoleWatcher.install(fakeConsole);
+      _ConsoleWatcher.install(fakeOptions, fakeConsole);
       fakeConsole.error("oops");
       expect(fakeAgent.captureError).toHaveBeenCalled();
     });

--- a/test/watchers/NetworkWatcher.test.ts
+++ b/test/watchers/NetworkWatcher.test.ts
@@ -4,6 +4,7 @@ import { NetworkWatcher, Watcher } from "../../src/watchers";
 import { Agent } from "../../src/Agent";
 import { AgentRegistrar } from "../../src/AgentRegistrar";
 import { TrackJSOptions } from "../../src/types";
+import { TrackJSEntry } from "../../src/types/TrackJSCapturePayload";
 
 const _NetworkWatcher = NetworkWatcher as Watcher;
 
@@ -55,7 +56,7 @@ describe("NetworkWatcher", () => {
       req.end();
     });
 
-    it("https patched to intercept request", (done) => {
+    it("when enabled, https patched to intercept request", (done) => {
       _NetworkWatcher.install(fakeOptions);
       fakeAgent.telemetry.add = jest.fn();
       const req = https.request("https://example.com/?foo=bar", { method: "GET" }, (res) => {
@@ -71,5 +72,37 @@ describe("NetworkWatcher", () => {
       });
       req.end();
     });
+
+    it("when error enabled, captures error from failing request", (done) => {
+      _NetworkWatcher.install({ network: { enabled: true, error: true }});
+      fakeAgent.telemetry.add = jest.fn();
+      fakeAgent.captureError = jest.fn();
+      const req = https.request("https://httpstat.us/501", { method: "GET" }, (res) => {
+        setTimeout(() => {
+          expect(fakeAgent.captureError).toHaveBeenCalledWith(
+            expect.objectContaining({
+              stack: expect.any(String)
+            }),
+            TrackJSEntry.Network
+          );
+          done();
+        });
+      });
+      req.end();
+    });
+
+    it("when error disabled, no errors captured", (done) => {
+      _NetworkWatcher.install({ network: { enabled: true, error: false }});
+      fakeAgent.telemetry.add = jest.fn();
+      fakeAgent.captureError = jest.fn();
+      const req = https.request("https://httpstat.us/501", { method: "GET" }, (res) => {
+        setTimeout(() => {
+          expect(fakeAgent.captureError).not.toHaveBeenCalled();
+          done();
+        });
+      });
+      req.end();
+    });
+
   });
 });

--- a/test/watchers/NetworkWatcher.test.ts
+++ b/test/watchers/NetworkWatcher.test.ts
@@ -3,8 +3,9 @@ import https from "https";
 import { NetworkWatcher, Watcher } from "../../src/watchers";
 import { Agent } from "../../src/Agent";
 import { AgentRegistrar } from "../../src/AgentRegistrar";
+import { TrackJSOptions } from "../../src/types";
 
-let _NetworkWatcher = NetworkWatcher as Watcher;
+const _NetworkWatcher = NetworkWatcher as Watcher;
 
 beforeAll(() => {
   Agent.defaults.dependencies = false;
@@ -14,42 +15,61 @@ jest.mock("net");
 
 describe("NetworkWatcher", () => {
   describe("install()", () => {
+    let fakeOptions: TrackJSOptions;
     let fakeAgent: Agent;
 
     beforeEach(() => {
+      fakeOptions = { network: { error: true, enabled: true } };
       fakeAgent = new Agent({ token: "test" });
       AgentRegistrar.init(fakeAgent);
-      _NetworkWatcher.install();
     });
 
     afterEach(() => {
       _NetworkWatcher.uninstall();
     });
 
-    it("http patched to intercept request", async () => {
+    it("when disabled, does nothing", (done) => {
+      _NetworkWatcher.install({ network: { enabled: false } });
       fakeAgent.telemetry.add = jest.fn();
-      await http.request("http://example.com/?foo=bar");
-      expect(fakeAgent.telemetry.add).toHaveBeenCalledWith(
-        "n",
-        expect.objectContaining({
-          method: "GET",
-          url: "http://example.com/?foo=bar",
-          startedOn: expect.any(String)
-        })
-      );
+      http.get("http://example.com/?foo=bar", () => {
+        expect(fakeAgent.telemetry.add).not.toHaveBeenCalled();
+        done();
+      });
     });
 
-    it("https patched to intercept request", async () => {
+    it("when enabled, http patched to intercept request", (done) => {
+      _NetworkWatcher.install({ network: { enabled: true } });
       fakeAgent.telemetry.add = jest.fn();
-      await https.request("https://example.com/?foo=bar");
-      expect(fakeAgent.telemetry.add).toHaveBeenCalledWith(
-        "n",
-        expect.objectContaining({
-          method: "GET",
-          url: "https://example.com/?foo=bar",
-          startedOn: expect.any(String)
-        })
-      );
+
+      const req = http.request("http://example.com/?foo=bar", { method: "GET" }, (resp) => {
+        expect(fakeAgent.telemetry.add).toHaveBeenCalledWith(
+          "n",
+          expect.objectContaining({
+            method: "GET",
+            url: "http://example.com/?foo=bar",
+            startedOn: expect.any(String)
+          })
+        );
+        done();
+      });
+      req.end();
+    });
+
+    it("https patched to intercept request", (done) => {
+      _NetworkWatcher.install(fakeOptions);
+      fakeAgent.telemetry.add = jest.fn();
+      const req = https.request("https://example.com/?foo=bar", { method: "GET" }, (res) => {
+        expect(fakeAgent.telemetry.add).toHaveBeenCalledWith(
+          "n",
+          expect.objectContaining({
+            method: "GET",
+            url: "https://example.com/?foo=bar",
+            startedOn: expect.any(String)
+          })
+        );
+        done();
+      });
+      req.end();
     });
   });
 });


### PR DESCRIPTION
This change adds install options for configuring Network Telemetry for parity with the Browser Agent:

```
TrackJS.install({
  network: {
    error: true, // whether errors should be automatically captured from network status >=400
    enabled: true // whether network requests should be automatically added to telemetry
  }
});
```

This was the first nested option for the node agent, so we needed a utility function to assign userOpts ontop of the defaults.

The installation object needed to be passed down to the `Watcher` implementations so they can make these decisions. This should make it easy to add similar options for console, promises, etc. when they are needed.

While adding this, we discovered that our network wrapping did not capture requests made with the shorthand `http.get` and `https.get` methods. We have expanded the wrapping to include this.

